### PR TITLE
Allow use raw body.

### DIFF
--- a/lib/paypal-ipn.js
+++ b/lib/paypal-ipn.js
@@ -21,19 +21,19 @@ exports.verify = function verify(params, settings, callback) {
     return;
   }
 
-  params.cmd = '_notify-validate';
-
-  var body = qs.stringify(params);
+  var prefix = 'cmd=_notify-validate&';
+  var body = prefix + (typeof params === 'string' ? params : (Buffer.isBuffer(params) ? params.toString() : qs.stringify(params)));
+  var test_ipn = params.test_ipn || body.indexOf('&test_ipn=1') > 0;
 
   //Set up the request to paypal
   var req_options = {
-    host: (params.test_ipn) ? SANDBOX_URL : REGULAR_URL,
+    host: test_ipn ? SANDBOX_URL : REGULAR_URL,
     method: 'POST',
     path: '/cgi-bin/webscr',
     headers: {'Content-Length': body.length}
   };
 
-  if (params.test_ipn && !settings.allow_sandbox) {
+  if (test_ipn && !settings.allow_sandbox) {
     process.nextTick(function () {
       callback(new Error('Received request with test_ipn parameter while sandbox is disabled'));
     });


### PR DESCRIPTION
in express with body_parser, to get req.rawBody but keep the parsed req.body, can use following code:

```
app.use(bodyParser.urlencoded({
    extended: false,
    verify: function (req, res, buf, encoding) {
        req.rawBody = buf;
    }
}));
```

then we can use req.rawBody to do the verify, without any failure chance due to the urlencode.